### PR TITLE
Don't go over 64 characters for transient names

### DIFF
--- a/opengraph-oembed.php
+++ b/opengraph-oembed.php
@@ -130,7 +130,7 @@ class OpenGraph_oEmbed {
 		return $result;
 	}
 	private static function get_data( $url ) {
-		$result = get_transient( 'opengraph_oembed_'.md5( $url ) );
+		$result = get_transient( 'og_oembed_'.md5( $url ) );
 		if ( !$result ) {
 			require_once( 'includes/opengraph.php' );
 			$data = wp_remote_retrieve_body( wp_remote_get( $url ) );
@@ -143,7 +143,7 @@ class OpenGraph_oEmbed {
 					}				
 				}
 				if ( $result ) {
-					set_transient( 'opengraph_oembed_'.md5( $url ), $result, DAY_IN_SECONDS );
+					set_transient( 'og_oembed_'.md5( $url ), $result, DAY_IN_SECONDS );
 				}				
 			}
 		}


### PR DESCRIPTION
option_name in wp_options only handles up to 64 characters.

Before this patch, that would cause transients to never be properly saved.

As an example, these transients are 69 and 61 characters long:

`
_transient_timeout_opengraph_oembed_bcb0fd6c871f6dd865003a4c930a2939
_transient_opengraph_oembed_bcb0fd6c871f6dd865003a4c930a2939
`

To fix this, we simply shorten the key a little to get us down to 62 and 57 characters respectively.
