### PR TITLE
Remove extra word

### DIFF
--- a/templates/opengraph-oembed.php
+++ b/templates/opengraph-oembed.php
@@ -4,5 +4,5 @@
 		<h2>%%title%%</h2>
 		<div class="opengraph_oembed_description">%%description%%</div>
 	</a>
-	<p class="opengraph_oembed_site">general via %%site_name%%</p>
+	<p class="opengraph_oembed_site">via %%site_name%%</p>
 </div>


### PR DESCRIPTION
Is there some idea behind why the word "general" is in there? If not we should remove it.

I tried switching it to:
`Written by <Author name> on <Site name>`

..but I couldn't find any way to pull out the names. For FB / Twitter, you seem to get ID:s. Author support probably another ticket though. :smile: 
