### PR TITLE
Avoid undefined errors when 'image' or 'site_url' aren't set.

### DIFF
--- a/content-cards.php
+++ b/content-cards.php
@@ -241,9 +241,10 @@ class Content_Cards {
 
 function get_cc_data( $key ) {
 	return Content_Cards::$temp_data[$key];
+	return isset(Content_Cards::$temp_data[$key]) ? Content_Cards::$temp_data[$key] : '';
 }
 function the_cc_data( $key ) {
-	echo Content_Cards::$temp_data[$key];
+	echo get_cc_data( $key );
 }
 function the_cc_target() {
 	echo Content_Cards::$temp_data['target'] ? ' target="_blank"' : '';


### PR DESCRIPTION
Makes sure keys are in the array before echo / return.
