### PR TITLE
A candidate fix for #6 - Postmeta storage

### DIFF
--- a/content-cards.php
+++ b/content-cards.php
@@ -362,7 +362,6 @@ class Content_Cards {
 				$url,
 				$url_md5,
 			);
-			var_dump($args);
 			if ( false === wp_next_scheduled( 'content_cards_update', $args ) ) {
 				wp_schedule_single_event( time() + MINUTE_IN_SECONDS, 'content_cards_update', $args );
 			}
@@ -381,6 +380,13 @@ class Content_Cards {
 	 * @return null
 	 */
 	public static function update_data( $post_id, $url, $url_md5 ) {
+		// remove link metadata if link is not in post_content anymore
+		$content = get_post_field('post_content', $post_id);
+		if ( false === strpos( $content, $url ) ) {
+			delete_post_meta( $post_id, 'content_cards_'.$url_md5 );
+			return false;
+		}
+		// update link metadata from remote source
 		$result = get_post_meta( $post_id, 'content_cards_'.$url_md5, true );
 		if ( $result && time() - $result['cc_last_updated'] > self::$options['update_interval'] ) {
 			$new_result = self::get_remote_data( $url );

--- a/content-cards.php
+++ b/content-cards.php
@@ -9,7 +9,7 @@ License: GPL2
 */
 
 add_action( 'plugins_loaded', array( 'Content_Cards', 'init' ) );
-
+register_uninstall_hook( __FILE__, array( 'Content_Cards', 'uninstall' ) );
 /**
  * Main plugin class
  *
@@ -54,6 +54,12 @@ class Content_Cards {
 	    add_filter( 'mce_buttons', 			array( 'Content_Cards', 'editor_button' ) );
 	}
 
+	public static function uninstall() {
+		global $wpdb;
+		$q = "DELETE FROM `{$wpdb->postmeta}` WHERE `meta_key` LIKE 'content_cards_%'";
+		$wpdb->query( $q );
+		delete_option( 'content-cards_options' );
+	}
 	/**
 	 * Enqueues TinyMCE button JS
 	 *

--- a/content-cards.php
+++ b/content-cards.php
@@ -20,7 +20,7 @@ class Content_Cards {
 		'patterns' => "wptavern.com\r\nwordpress.org",
 		'skin' => 'default',
 		'target' => false,
-		'update_interval' => MINUTE_IN_SECONDS,
+		'update_interval' => DAY_IN_SECONDS,
 	);
 	private static $stylesheet = '';
 	public static $temp_data = array();
@@ -180,6 +180,20 @@ class Content_Cards {
 							'label'			=> __('Open links in new tab?','content-cards'),
 						),
 						'callback' => 'checkbox',
+					),
+					'update_interval' => array(
+						'title'=>__('Update Interval','content-cards'),
+						'args' => array (
+							'values' => array(
+								HOUR_IN_SECONDS     => __( 'Hourly', 'content-cards' ),
+								2 * HOUR_IN_SECONDS => __( 'Every 2 Hours', 'content-cards' ),
+								6 * HOUR_IN_SECONDS => __( 'Every 6 Hours', 'content-cards' ),
+								DAY_IN_SECONDS / 2  => __( 'Twice Daily', 'content-cards' ),
+								DAY_IN_SECONDS      => __( 'Daily', 'content-cards' ),
+							),
+							'description' => __( 'How often should Content Cards check for changes in OpenGraph data?', 'content-cards' ),
+						),
+						'callback' => 'select',
 					),
 				),
 			),
@@ -355,6 +369,17 @@ class Content_Cards {
 		}
 		return $result;
 	}
+
+	/**
+	 * Updates OpenGraph info
+	 * from remote site
+	 * via wp_cron task
+	 *
+	 * @param $post_id
+	 * @param $url
+	 * @param $url_md5	 
+	 * @return null
+	 */
 	public static function update_data( $post_id, $url, $url_md5 ) {
 		$result = get_post_meta( $post_id, 'content_cards_'.$url_md5, true );
 		if ( $result && time() - $result['cc_last_updated'] > self::$options['update_interval'] ) {


### PR DESCRIPTION
A candidate fix for #6:
- stores OG data in postmeta
- updates OG data via WP_Cron
- update interval can be tweaked in Options
- removes OG data for links that were removed from `post_content`

Thoughts, @khromov ?

I only see one performance bottleneck now - the initial request for OG data still happens on the first pageview, not in the editor/via cron, if link is inserted via shortcode. It is not a big problem if request is successful, as then it happens only once. But if request fails (bad link, bad connection, remote server down, no OG tags in remote site etc.), Content Cards would try again (on every pageview), until it succeeds. Maybe some kind of throttling should be added for this case?
