### PR TITLE
Template validation

### DIFF
--- a/content-cards.php
+++ b/content-cards.php
@@ -545,10 +545,15 @@ class Content_Cards {
  * Returns Content Card data, template function.
  *
  * @param $key
+ * @param $sanitize
  * @return mixed
  */
-function get_cc_data( $key ) {
-	return isset(Content_Cards::$temp_data[$key]) ? Content_Cards::$temp_data[$key] : '';
+function get_cc_data( $key, $sanitize = false ) {
+	$result = isset(Content_Cards::$temp_data[$key]) ? Content_Cards::$temp_data[$key] : '';
+	if (is_callable($sanitize)) {
+		$result = call_user_func( $sanitize, $result );
+	}
+	return $result;
 }
 
 /**
@@ -556,8 +561,8 @@ function get_cc_data( $key ) {
  *
  * @param $key
  */
-function the_cc_data( $key ) {
-	echo get_cc_data( $key );
+function the_cc_data( $key, $sanitize = false ) {
+	echo get_cc_data( $key, $sanitize );
 }
 
 /**

--- a/skins/default-dark/content-cards.php
+++ b/skins/default-dark/content-cards.php
@@ -1,19 +1,19 @@
 <div class="content_cards_card">
 	<?php if ( get_cc_data( 'image' ) ) : ?>
 		<div class="content_cards_image">
-				<a class="content_cards_image_link" href="<?php echo esc_url( get_cc_data( 'url' ) ); ?>"<?php the_cc_target(); ?>>
-						<img src="<?php echo esc_url( get_cc_data( 'image' ) ); ?>" alt="<?php echo esc_attr( get_cc_data( 'title' ) ); ?>" />
+				<a class="content_cards_image_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
+						<img src="<?php the_cc_data( 'image', 'esc_url' ); ?>" alt="<?php the_cc_data( 'title', 'esc_attr' ); ?>" />
 				</a>
 		</div>
 	<?php endif; ?>
 
 	<div class="content_cards_title">
-		<a class="content_cards_title_link" href="<?php echo esc_url( get_cc_data( 'url' ) ); ?>"<?php the_cc_target(); ?>>
+		<a class="content_cards_title_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
 			<?php the_cc_data( 'title' ); ?>
 		</a>
 	</div>
 	<div class="content_cards_description">
-		<a class="content_cards_description_link" href="<?php echo esc_url( get_cc_data( 'url' ) ); ?>"<?php the_cc_target(); ?>>
+		<a class="content_cards_description_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
 			<?php the_cc_data( 'description' ); ?>
 		</a>
 	</div>

--- a/skins/default/content-cards.php
+++ b/skins/default/content-cards.php
@@ -1,19 +1,19 @@
 <div class="content_cards_card">
 	<?php if ( get_cc_data( 'image' ) ) : ?>
 		<div class="content_cards_image">
-				<a class="content_cards_image_link" href="<?php echo esc_url( get_cc_data( 'url' ) ); ?>"<?php the_cc_target(); ?>>
-						<img src="<?php echo esc_url( get_cc_data( 'image' ) ); ?>" alt="<?php echo esc_attr( get_cc_data( 'title' ) ); ?>" />
+				<a class="content_cards_image_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
+						<img src="<?php the_cc_data( 'image', 'esc_url' ); ?>" alt="<?php the_cc_data( 'title', 'esc_attr' ); ?>" />
 				</a>
 		</div>
 	<?php endif; ?>
 
 	<div class="content_cards_title">
-		<a class="content_cards_title_link" href="<?php echo esc_url( get_cc_data( 'url' ) ); ?>"<?php the_cc_target(); ?>>
+		<a class="content_cards_title_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
 			<?php the_cc_data( 'title' ); ?>
 		</a>
 	</div>
 	<div class="content_cards_description">
-		<a class="content_cards_description_link" href="<?php echo esc_url( get_cc_data( 'url' ) ); ?>"<?php the_cc_target(); ?>>
+		<a class="content_cards_description_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
 			<?php the_cc_data( 'description' ); ?>
 		</a>
 	</div>


### PR DESCRIPTION
fixes #15; `get_cc_data($key, $sanitize=false)` and `the_cc_data($key, $sanitize=false)` now has a second parameter to pass `callable` function to sanitize/escape the output. Updated `default` and `default-dark` skins accordingly.

Thoughts @khromov ?
