### PR TITLE
detect favicon, force absolute urls; fixes #41 and #44

### DIFF
--- a/skins/default-dark/content-cards.css
+++ b/skins/default-dark/content-cards.css
@@ -81,3 +81,7 @@ html body .content_cards_card a:active {
 	margin: 0;
 	padding: 0;
 }
+
+.content_cards_favicon {
+	max-height: 24px;
+}

--- a/skins/default-dark/content-cards.php
+++ b/skins/default-dark/content-cards.php
@@ -18,6 +18,7 @@
 		</a>
 	</div>
 	<div class="content_cards_site_name">
+		<?php if ( get_cc_data('favicon') ) : ?><img src="<?php the_cc_data( 'favicon', 'esc_url' ); ?>" alt="<?php the_cc_data( 'site_name', 'esc_attr' ); ?>" class="content_cards_favicon"/><?php endif; ?>
 		<?php the_cc_data( 'site_name' ); ?>
 	</div>
 </div>

--- a/skins/default/content-cards.css
+++ b/skins/default/content-cards.css
@@ -81,3 +81,7 @@ html body .content_cards_card a:active {
 	margin: 0;
 	padding: 0;
 }
+
+.content_cards_favicon {
+	max-height: 24px;
+}

--- a/skins/default/content-cards.php
+++ b/skins/default/content-cards.php
@@ -18,6 +18,7 @@
 		</a>
 	</div>
 	<div class="content_cards_site_name">
+		<?php if ( get_cc_data('favicon') ) : ?><img src="<?php the_cc_data( 'favicon', 'esc_url' ); ?>" alt="<?php the_cc_data( 'site_name', 'esc_attr' ); ?>" class="content_cards_favicon"/><?php endif; ?>
 		<?php the_cc_data( 'site_name' ); ?>
 	</div>
 </div>


### PR DESCRIPTION
This adds:
- support for basic `favicon` detection when getting remote data; (#44)
- template changes to display favicon;
- `force_absolute_url` method to ensure favicon url is always absolute. The same method applied for `image` field to fix #41. 

![selection_016](https://cloud.githubusercontent.com/assets/3252474/9657135/21afb2d8-5247-11e5-9da9-f183ee1de10a.png)
