### PR TITLE
Feature image cache

### DIFF
--- a/content-cards.php
+++ b/content-cards.php
@@ -636,14 +636,12 @@ class Content_Cards {
 	public static function image_cleanup( $image_id ) {
 		$image_meta = get_post_meta( $image_id, 'content_cards_cached', true );
 		$post_id = $image_meta['post_id'];
-		$image_url = $image_meta['original_url'];
 		$meta = get_post_meta( $post_id ); 
 		$found = false;
 		foreach ( $meta as $key => $value ) {
 			if ( 0 === strpos( $key, 'content_cards_') ) {
 				$value = unserialize($value[0]);
-				if ( $image_url === $value['image'] )  {
-					var_dump('rastas');
+				if ( isset( $value['image_id'] ) && $image_id === $value['image_id'] )  {
 					$found = $key;
 					break;
 				}

--- a/content-cards.php
+++ b/content-cards.php
@@ -641,7 +641,7 @@ class Content_Cards {
 		foreach ( $meta as $key => $value ) {
 			if ( 0 === strpos( $key, 'content_cards_') ) {
 				$value = unserialize($value[0]);
-				if ( isset( $value['image_id'] ) && $image_id === $value['image_id'] )  {
+				if ( isset( $value['image_id'] ) && $image_id == $value['image_id'] )  {
 					$found = $key;
 					break;
 				}
@@ -917,4 +917,47 @@ function the_cc_data( $key, $sanitize = false ) {
  */
 function the_cc_target() {
 	echo Content_Cards::$temp_data['target'] ? ' target="_blank"' : '';
+}
+
+/**
+ * Returns cached image url or original image url, if cache is not available
+ *
+ * @param $size - WordPress image size
+ * @param $sanitize
+ */
+function get_cc_image( $size = 'thumbnail', $sanitize = false ) {
+	if ( isset(Content_Cards::$temp_data['image_id']) && Content_Cards::$temp_data['image_id'] ) {
+		$result = wp_get_attachment_image_src( Content_Cards::$temp_data['image_id'], $size );
+		$result = $result[0];
+		if (is_callable($sanitize)) {
+			$result = call_user_func( $sanitize, $result );
+		}
+		return $result;
+	} else if ( isset(Content_Cards::$temp_data['image']) && Content_Cards::$temp_data['image'] ) {
+		return get_cc_data( 'image', $sanitize );
+	} else {
+		return false;
+	}
+}
+
+/**
+ * Prints cached image original image, if cache is not available
+ *
+ * @param $size - WordPress image size
+ * @param $args
+ */
+function the_cc_image( $size = 'thumbnail', $args = array() ) {
+	$defaults = array(
+		'alt' => get_cc_data( 'title' ),
+	);
+	$args = wp_parse_args( $args, $defaults );
+	$attributes = array();
+	foreach ($args as $key => $value) {
+		$value = esc_attr( $value );
+		$attributes[] = "{$key}=\"{$value}\"";
+	}
+	$attributes = implode( ' ', $attributes );
+	$img = get_cc_image( $size, 'esc_url' );
+	$result = "<img src=\"{$img}\" {$attributes}>";
+	echo $result;
 }

--- a/skins/default-dark/content-cards.php
+++ b/skins/default-dark/content-cards.php
@@ -2,7 +2,7 @@
 	<?php if ( get_cc_data( 'image' ) ) : ?>
 		<div class="content_cards_image">
 				<a class="content_cards_image_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
-						<img src="<?php the_cc_data( 'image', 'esc_url' ); ?>" alt="<?php the_cc_data( 'title', 'esc_attr' ); ?>" />
+					<?php the_cc_image( 'full' ); ?>
 				</a>
 		</div>
 	<?php endif; ?>

--- a/skins/default/content-cards.php
+++ b/skins/default/content-cards.php
@@ -2,7 +2,7 @@
 	<?php if ( get_cc_data( 'image' ) ) : ?>
 		<div class="content_cards_image">
 				<a class="content_cards_image_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
-						<?php the_cc_image( 'full' ); ?><!--<img src="<?php the_cc_data( 'image', 'esc_url' ); ?>" alt="<?php the_cc_data( 'title', 'esc_attr' ); ?>" />-->
+					<?php the_cc_image( 'full' ); ?>
 				</a>
 		</div>
 	<?php endif; ?>

--- a/skins/default/content-cards.php
+++ b/skins/default/content-cards.php
@@ -2,7 +2,7 @@
 	<?php if ( get_cc_data( 'image' ) ) : ?>
 		<div class="content_cards_image">
 				<a class="content_cards_image_link" href="<?php the_cc_data( 'url', 'esc_url' ); ?>"<?php the_cc_target(); ?>>
-						<img src="<?php the_cc_data( 'image', 'esc_url' ); ?>" alt="<?php the_cc_data( 'title', 'esc_attr' ); ?>" />
+						<?php the_cc_image( 'full' ); ?><!--<img src="<?php the_cc_data( 'image', 'esc_url' ); ?>" alt="<?php the_cc_data( 'title', 'esc_attr' ); ?>" />-->
 				</a>
 		</div>
 	<?php endif; ?>


### PR DESCRIPTION
Images are now being cached in Media Library;
New template tags - `the_cc_image($size, $args)` and `get_cc_image( $size, $sanitize)` introduced to leverage cached images.

This fixes #40 
