### PR TITLE
Add content_cards_options filter and allow disabling the admin page

### DIFF
--- a/content-cards.php
+++ b/content-cards.php
@@ -24,6 +24,7 @@ class Content_Cards {
 		'cleanup_interval' => DAY_IN_SECONDS,
 		'default_image' => '',
 		'word_limit' => 55,
+		'enable_admin_page' => true
 	);
 	private static $stylesheet = '';
 	public static $temp_data = array();
@@ -31,7 +32,7 @@ class Content_Cards {
 	public static function init() {
 		$options = get_option( 'content-cards_options' );
 
-		self::$options = wp_parse_args( $options, self::$options );
+		self::$options = apply_filters('content_cards_options', wp_parse_args( $options, self::$options ));
 
 		if ( isset( self::$options['theme'] ) ) {
 			self::$options['skin'] = self::$options['theme'];
@@ -41,7 +42,11 @@ class Content_Cards {
 		add_action( 'wp_enqueue_scripts', 	array( 'Content_Cards', 'styles' ) );
 		add_action( 'admin_enqueue_scripts',array( 'Content_Cards', 'admin_scripts' ) );
 		add_action( 'admin_init', 			array( 'Content_Cards', 'admin_init' ) );
-		add_action( 'admin_menu', 			array( 'Content_Cards', 'admin_menu' ) );
+
+		if(self::$options['enable_admin_page']) {
+			add_action( 'admin_menu', 			array( 'Content_Cards', 'admin_menu' ) );
+		}
+
 		add_action( 'content_cards_update', array( 'Content_Cards', 'update_data' ), 10, 3 );
 		add_action( 'content_cards_retry',  array( 'Content_Cards', 'retry_data' ), 10, 4 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,30 @@ Also since `v0.9.1` you can use `'favicon'` key in `get_cc_data()/the_cc_data()`
 
 This plugin requires WP_Cron to be in proper working order.
 
+= Override the default options =
+
+If you are running this plugin on a multisite, you may wish to set site-wide settings and disable the Content Cards settings page on each separate blog.
+
+To do this, you can use the `content_cards_options` hook, like this:
+
+    add_filter('content_cards_options', function($data) {
+
+        //Disable admin page
+        $data['enable_admin_page'] = false;
+
+        return $data;
+    });
+
+You can also override a number of other options using this hook. For example, here we set the theme to "default-dark":
+
+    add_filter('content_cards_options', function($data) {
+
+        //Disable admin page
+        $data['skin'] = 'default-dark';
+
+        return $data;
+    });
+
 == Installation ==
 
 * Go to your admin area and select Plugins -> Add new from the menu.


### PR DESCRIPTION
New filter - `content_cards_options`

A filter is great for multisite installs. Disabling the admin page also makes sense since you may want to control it centrally through code.
