### PR TITLE
Don't specify "tested up to" for minor versions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: ideag, khromov
 Tags: opengraph, open graph, oembed, link cards, snippet, rich snippet, content card
 Donate link: http://arunas.co#coffee
 Requires at least: 4.1.0
-Tested up to: 4.4.0
+Tested up to: 4.4
 Stable tag: 0.9.4
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
WP.org will append the last minor version if we specify 4.4. On the other hand, specifiying minor version may impact our visibility in the plugin store if we don't update it for every minor version.
