### PR TITLE
Add textdomain

### DIFF
--- a/content-cards.php
+++ b/content-cards.php
@@ -6,6 +6,7 @@ Version: 0.9.5
 Author: Arūnas Liuiza
 Author URI: http://arunas.co
 License: GPL2
+Text Domain: content-cards
 */
 
 add_action( 'plugins_loaded', array( 'Content_Cards', 'init' ) );


### PR DESCRIPTION
This shouldn't require a tag, just a push to SVN trunk so we can translate through the UI: 
https://translate.wordpress.org/locale/sv/default/wp-plugins/content-cards